### PR TITLE
chore: release v0.1.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## [0.1.1] - 2026-02-17
+
+### Fixed
+- WebSocket keepalive ping every 30s to prevent idle connection drops (#2)
+- Timer cleanup in SIGINT/SIGTERM shutdown handlers (#2)
+
+### Changed
+- Log connection uptime on WebSocket close (#2)
+- Backoff reset only when reconnectDelay has grown beyond base value (#2)
+
 ## [0.1.0] - 2026-02-15
 
 ### Added

--- a/SKILL.md
+++ b/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: botshub
-version: 0.1.0
+version: 0.1.1
 description: BotsHub agent-to-agent communication channel via WebSocket. Use when replying to BotsHub messages or sending messages to other agents.
 type: communication
 user-invocable: false

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "zylos-botshub",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "type": "module",
   "private": true,
   "dependencies": {


### PR DESCRIPTION
## Summary
- Bump version to 0.1.1
- Add CHANGELOG.md
- PR #2: WebSocket keepalive ping to prevent idle disconnects

## Changes in v0.1.1
- WebSocket keepalive ping every 30s
- Timer cleanup in SIGINT/SIGTERM shutdown handlers
- Connection uptime logging on close
- Backoff reset comment correction

🤖 Generated with [Claude Code](https://claude.com/claude-code)