### PR TITLE
feat: SDK integration + thread event handling (v0.3.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,20 @@
 # Changelog
 
+## [0.3.0] - 2026-02-22
+
+### Added
+- **botshub-sdk integration**: Outbound messages sent via SDK instead of raw curl
+- **Thread event handling**: thread_created, thread_message, thread_updated, thread_artifact, thread_participant events forwarded to C4
+- **Thread message sending**: `send.js thread:<id> "message"` for thread replies
+- **Agent presence logging**: agent_online/agent_offline events logged
+- **Shared env module**: DRY config/env loading across bot.js and send.js
+
+### Changed
+- send.js rewritten to use BotsHubClient SDK (replaces curl/execSync)
+- bot.js refactored with switch-based event dispatch
+- WebSocket token URL-encoded for safety
+- Version bumped to 0.3.0
+
 ## [0.2.0] - 2026-02-19
 
 ### Changed

--- a/SKILL.md
+++ b/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: botshub
-version: 0.2.0
+version: 0.3.0
 description: BotsHub agent-to-agent communication channel via WebSocket. Use when replying to BotsHub messages or sending messages to other agents.
 type: communication
 user-invocable: false
@@ -46,11 +46,13 @@ Agent-to-agent communication via BotsHub — a messaging hub for AI agents.
 ## Dependencies
 
 - **comm-bridge**: Required for forwarding messages to Claude via C4 protocol
+- **botshub-sdk**: TypeScript SDK for BotsHub B2B Protocol (installed via npm)
 
 ## When to Use
 
 - Replying to messages from other agents on BotsHub
 - Sending messages to specific agents
+- Working with collaboration threads (create, message, artifacts)
 - Checking who's online
 
 ## How to Send Messages
@@ -65,12 +67,15 @@ Or directly:
 node ~/zylos/.claude/skills/botshub/scripts/send.js <agent_name> "message"
 ```
 
-## Check Peers
+## How to Send Thread Messages
 
 ```bash
-curl -sf "$(jq -r .hub_url ~/zylos/components/botshub/config.json)/api/peers" \
-  -H "Authorization: Bearer $(jq -r .agent_token ~/zylos/components/botshub/config.json)" \
-  --proxy "${HTTPS_PROXY:-}"
+node ~/zylos/.claude/skills/botshub/scripts/send.js thread:<thread_id> "message"
+```
+
+Or via C4 Bridge:
+```bash
+node ~/zylos/.claude/skills/comm-bridge/scripts/c4-send.js "botshub" "thread:<thread_id>" "message"
 ```
 
 ## Config Location
@@ -92,4 +97,9 @@ Incoming messages appear as:
 ```
 [BotsHub DM] agent-name said: message content
 [BotsHub GROUP:channel-name] agent-name said: message content
+[BotsHub Thread] New thread created: "topic" (type: request, id: uuid)
+[BotsHub Thread:uuid] agent-name said: message content
+[BotsHub Thread:uuid] Thread "topic" updated: status (status: resolved)
+[BotsHub Thread:uuid] Artifact added: "title" (type: markdown)
+[BotsHub Thread:uuid] agent-name joined the thread
 ```

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,108 @@
+{
+  "name": "zylos-botshub",
+  "version": "0.3.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "zylos-botshub",
+      "version": "0.3.0",
+      "dependencies": {
+        "botshub-sdk": "file:../botshub-sdk",
+        "https-proxy-agent": "^7.0.6",
+        "undici": "^7.22.0",
+        "ws": "^8.19.0"
+      }
+    },
+    "../botshub-sdk": {
+      "version": "0.1.0",
+      "license": "MIT",
+      "dependencies": {
+        "ws": "^8.18.0"
+      },
+      "devDependencies": {
+        "@types/ws": "^8.5.0",
+        "typescript": "5.7"
+      }
+    },
+    "node_modules/agent-base": {
+      "version": "7.1.4",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
+      "integrity": "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/botshub-sdk": {
+      "resolved": "../botshub-sdk",
+      "link": true
+    },
+    "node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/https-proxy-agent": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
+      "integrity": "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==",
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.2",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "license": "MIT"
+    },
+    "node_modules/undici": {
+      "version": "7.22.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.22.0.tgz",
+      "integrity": "sha512-RqslV2Us5BrllB+JeiZnK4peryVTndy9Dnqq62S3yYRRTj0tFQCwEniUy2167skdGOy3vqRzEvl1Dm4sV2ReDg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.18.1"
+      }
+    },
+    "node_modules/ws": {
+      "version": "8.19.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.19.0.tgz",
+      "integrity": "sha512-blAT2mjOEIi0ZzruJfIhb3nps74PRWTCz1IjglWEEpQl5XS/UNama6u2/rjFkDDouqr4L67ry+1aGIALViWjDg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,9 +1,11 @@
 {
   "name": "zylos-botshub",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "type": "module",
   "private": true,
   "dependencies": {
+    "botshub-sdk": "github:coco-xyz/botshub-sdk",
+    "undici": "^7.22.0",
     "ws": "^8.18.0",
     "https-proxy-agent": "^7.0.5"
   }

--- a/scripts/send.js
+++ b/scripts/send.js
@@ -1,77 +1,52 @@
 #!/usr/bin/env node
 /**
  * zylos-botshub send interface
- * Usage: node send.js <to_agent> "<message>"
- * Called by C4 comm-bridge to send outbound messages via BotsHub API.
+ *
+ * Usage:
+ *   node send.js <to_agent> "<message>"          — Send DM
+ *   node send.js thread:<thread_id> "<message>"   — Send thread message
+ *
+ * Called by C4 comm-bridge to send outbound messages via BotsHub SDK.
  */
 
-import fs from 'fs';
-import path from 'path';
-import { execSync } from 'child_process';
-
-const HOME = process.env.HOME;
-const CONFIG_PATH = path.join(HOME, 'zylos/components/botshub/config.json');
-
-// Load .env
-const envPath = path.join(HOME, 'zylos/.env');
-if (fs.existsSync(envPath)) {
-  const envContent = fs.readFileSync(envPath, 'utf8');
-  for (const line of envContent.split('\n')) {
-    const trimmed = line.trim();
-    if (!trimmed || trimmed.startsWith('#')) continue;
-    const eqIdx = trimmed.indexOf('=');
-    if (eqIdx === -1) continue;
-    const key = trimmed.slice(0, eqIdx);
-    const val = trimmed.slice(eqIdx + 1);
-    if (!process.env[key]) process.env[key] = val;
-  }
-}
-
-const PROXY_URL = process.env.HTTPS_PROXY || process.env.HTTP_PROXY || '';
-
-function loadConfig() {
-  return JSON.parse(fs.readFileSync(CONFIG_PATH, 'utf8'));
-}
+import { BotsHubClient } from 'botshub-sdk';
+import { loadConfig, setupFetchProxy, PROXY_URL } from '../src/env.js';
 
 const args = process.argv.slice(2);
 if (args.length < 2) {
-  console.error('Usage: node send.js <to_agent> "<message>"');
+  console.error('Usage: node send.js <to_agent|thread:id> "<message>"');
   process.exit(1);
 }
 
-const toAgent = args[0];
+const target = args[0];
 const message = args.slice(1).join(' ');
 const config = loadConfig();
 
-const HUB_URL = config.hub_url;
-const TOKEN = config.agent_token;
-
-if (!HUB_URL || !TOKEN) {
+if (!config.hub_url || !config.agent_token) {
   console.error('Error: hub_url and agent_token not set in config.json');
   process.exit(1);
 }
 
-/**
- * Send DM to another agent via BotsHub API
- */
-async function sendMessage() {
-  const url = `${HUB_URL}/api/send`;
-  const payload = JSON.stringify({ to: toAgent, content: message });
-  const safePayload = payload.replace(/'/g, "'\\''");
+// Set up proxy for fetch before creating SDK client
+await setupFetchProxy();
 
-  let curlCmd = `curl -sf -X POST "${url}" -H "Authorization: Bearer ${TOKEN}" -H "Content-Type: application/json" -d '${safePayload}'`;
+const client = new BotsHubClient({
+  url: config.hub_url,
+  token: config.agent_token,
+});
 
-  if (PROXY_URL) {
-    curlCmd = curlCmd.replace('curl ', `curl --proxy "${PROXY_URL}" `);
+try {
+  if (target.startsWith('thread:')) {
+    // Thread message
+    const threadId = target.slice('thread:'.length);
+    await client.sendThreadMessage(threadId, message);
+    console.log(`Sent to thread ${threadId}: ${message.substring(0, 50)}...`);
+  } else {
+    // Direct message
+    await client.send(target, message);
+    console.log(`Sent to ${target}: ${message.substring(0, 50)}...`);
   }
-
-  try {
-    const result = execSync(curlCmd, { encoding: 'utf8' });
-    console.log(`Sent to ${toAgent}: ${message.substring(0, 50)}...`);
-  } catch (err) {
-    console.error(`Error sending to ${toAgent}: ${err.message}`);
-    process.exit(1);
-  }
+} catch (err) {
+  console.error(`Error sending to ${target}: ${err.message}`);
+  process.exit(1);
 }
-
-sendMessage();

--- a/src/env.js
+++ b/src/env.js
@@ -1,0 +1,49 @@
+/**
+ * Shared environment and config loader for zylos-botshub.
+ * Loads .env, reads config.json, and sets up HTTP proxy for fetch().
+ */
+
+import fs from 'fs';
+import path from 'path';
+
+const HOME = process.env.HOME;
+const CONFIG_PATH = path.join(HOME, 'zylos/components/botshub/config.json');
+const ENV_PATH = path.join(HOME, 'zylos/.env');
+
+// Load .env into process.env (don't override existing vars)
+if (fs.existsSync(ENV_PATH)) {
+  for (const line of fs.readFileSync(ENV_PATH, 'utf8').split('\n')) {
+    const trimmed = line.trim();
+    if (!trimmed || trimmed.startsWith('#')) continue;
+    const eqIdx = trimmed.indexOf('=');
+    if (eqIdx === -1) continue;
+    const key = trimmed.slice(0, eqIdx);
+    const val = trimmed.slice(eqIdx + 1);
+    if (!process.env[key]) process.env[key] = val;
+  }
+}
+
+export const PROXY_URL = process.env.HTTPS_PROXY || process.env.HTTP_PROXY || '';
+
+export function loadConfig() {
+  try {
+    return JSON.parse(fs.readFileSync(CONFIG_PATH, 'utf8'));
+  } catch (err) {
+    console.error('[botshub] Failed to load config:', err.message);
+    process.exit(1);
+  }
+}
+
+/**
+ * Set up HTTP proxy for native fetch() calls (used by botshub-sdk).
+ * Must be called before any SDK HTTP operations.
+ */
+export async function setupFetchProxy() {
+  if (!PROXY_URL) return;
+  try {
+    const { setGlobalDispatcher, ProxyAgent } = await import('undici');
+    setGlobalDispatcher(new ProxyAgent(PROXY_URL));
+  } catch {
+    console.warn('[botshub] Could not set up fetch proxy — undici not available');
+  }
+}


### PR DESCRIPTION
## Summary
- Add `botshub-sdk` as dependency — HTTP operations via SDK instead of raw curl
- `send.js` rewritten: `client.send()` for DM, `client.sendThreadMessage()` for thread replies
- Thread events handled: `thread_created`, `thread_message`, `thread_updated`, `thread_artifact`, `thread_participant` — all forwarded to C4
- Shared `src/env.js` module for DRY config/env loading + fetch proxy setup (undici)
- WebSocket token URL-encoded for safety
- Agent presence events (online/offline) logged

## Test plan
- [x] SDK import verified
- [x] Proxy setup (undici ProxyAgent) verified
- [x] Profile fetch via SDK works
- [x] DM send via SDK works (tested with zylos0t)
- [x] bot.js connects and receives messages
- [ ] Thread message send (needs active thread)
- [ ] Upgrade on live instance (after botshub-sdk#1 merged)

## Dependencies
- Requires coco-xyz/botshub-sdk#1 merged first (prepare script for GitHub installs)

🤖 Generated with [Claude Code](https://claude.com/claude-code)