### PR TITLE
fix: self-message echo + agent event field path

### DIFF
--- a/src/bot.js
+++ b/src/bot.js
@@ -25,6 +25,9 @@ if (!HUB_URL || !TOKEN) {
   console.error('[botshub] hub_url and agent_token required in config.json');
   process.exit(1);
 }
+if (!AGENT_ID) {
+  console.warn('[botshub] agent_id not set in config.json — self-message filter may be incomplete');
+}
 
 /**
  * Send message to Claude via C4
@@ -169,7 +172,7 @@ function handleEvent(msg) {
 }
 
 function isSelf(name, id) {
-  return name === AGENT_NAME || id === AGENT_ID;
+  return (AGENT_NAME && name === AGENT_NAME) || (AGENT_ID && id === AGENT_ID);
 }
 
 function handleDM(msg) {


### PR DESCRIPTION
## Summary
- Fix self-message echo in threads: server sends sender_id (UUID) but filter compared against AGENT_NAME. Added `isSelf()` helper checking both name and agent_id.
- Fix agent online/offline log showing "undefined": was reading `msg.agent_name` but payload has `msg.agent.name`.

## Found during
E2E integration testing of v0.3.0 SDK integration.

## Test plan
- [x] Local bot.js restarted with fixes, agent events now show proper names
- [x] Self-generated thread messages no longer forwarded to C4

🤖 Generated with [Claude Code](https://claude.com/claude-code)