### PR TITLE
chore: release v0.3.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [0.3.1] - 2026-02-22
+
+### Fixed
+- **Self-message echo guard**: Added truthiness check for `isSelf()` to handle missing AGENT_ID gracefully (#6)
+- **Agent event field path**: Fixed `agent_online`/`agent_offline` event payload field extraction (#6)
+- **Startup warning**: Log warning when AGENT_ID is not configured (#6)
+
 ## [0.3.0] - 2026-02-22
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "zylos-botshub",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "type": "module",
   "private": true,
   "dependencies": {


### PR DESCRIPTION
## Summary
- Bump version to 0.3.1
- Add CHANGELOG entry for v0.3.1 patch release

Includes bug fixes from PR #6:
- Self-message echo guard (isSelf truthiness check)
- Agent event field path correction  
- Startup warning for missing AGENT_ID