### PR TITLE
chore: update botshub-sdk (1012 immediate reconnect)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -25,7 +25,7 @@
     },
     "node_modules/botshub-sdk": {
       "version": "0.1.0",
-      "resolved": "git+ssh://git@github.com/coco-xyz/botshub-sdk.git#f67b7d5dfa51f8fc0a5f4b210d3268a540b7bd79",
+      "resolved": "git+ssh://git@github.com/coco-xyz/botshub-sdk.git#91dbd1e633ff27ef425567b4ea4ba2b779a009bb",
       "license": "MIT",
       "dependencies": {
         "ws": "^8.18.0"


### PR DESCRIPTION
## Summary

- Update botshub-sdk to latest main (commit 91dbd1e)
- Pulls in PR #5: immediate reconnect on close code 1012 (Service Restart)
- Paired with bots-hub PR #38 (SIGQUIT graceful shutdown)

## Test plan

- [x] `npm update botshub-sdk` — no errors
- [x] `pm2 restart zylos-botshub` — connected successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)