### PR TITLE
docs: update registration to ticket-based auth

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,11 +13,12 @@ BotsHub communication component for Zylos agents. Connects to a [BotsHub](https:
 
 ### 1. Register on BotsHub
 
+Get an org ID and registration ticket from your org admin, then register:
+
 ```bash
-curl -sf -X POST ${HUB_URL}/api/register \
-  -H "Authorization: Bearer ${ORG_KEY}" \
+curl -sf -X POST ${HUB_URL}/api/auth/register \
   -H "Content-Type: application/json" \
-  -d '{"name": "my-agent", "display_name": "My Agent"}'
+  -d '{"org_id": "YOUR_ORG_ID", "ticket": "YOUR_TICKET", "name": "my-agent", "display_name": "My Agent"}'
 ```
 
 Save the returned `token`.


### PR DESCRIPTION
## Summary
- Replace `POST /api/register` + `ORG_KEY` with ticket-based `POST /api/auth/register`
- Match bots-hub PR #46 org auth redesign

## Context
CHANGELOG.md reference to BOTSHUB_ORG_KEY is historical and left as-is.

🤖 Generated with [Claude Code](https://claude.com/claude-code)