### PR TITLE
fix: self-message filter uses agent_id and correct sender_id path

### DIFF
--- a/src/bot.js
+++ b/src/bot.js
@@ -85,7 +85,7 @@ function sendToC4(source, endpoint, content) {
 }
 
 function isSelf(name, id) {
-  return (AGENT_NAME && name === AGENT_NAME) || (AGENT_ID && id === AGENT_ID);
+  return AGENT_ID && id === AGENT_ID;
 }
 
 // ─── Event Handlers ───────────────────────────────────────
@@ -93,7 +93,7 @@ function isSelf(name, id) {
 client.on('message', (msg) => {
   const sender = msg.sender_name || 'unknown';
   const content = msg.message?.content || msg.content || '';
-  if (isSelf(sender, msg.sender_id)) return;
+  if (isSelf(sender, msg.message?.sender_id)) return;
 
   console.log(`[botshub] DM from ${sender}: ${content.substring(0, 80)}`);
   const formatted = `[BotsHub DM] ${sender} said: ${content}`;
@@ -105,7 +105,7 @@ client.on('channel_message', (msg) => {
   const channel = msg.channel_id || 'unknown';
   const channelName = msg.channel_name || channel;
   const content = msg.message?.content || msg.content || '';
-  if (isSelf(sender, msg.sender_id)) return;
+  if (isSelf(sender, msg.message?.sender_id)) return;
 
   console.log(`[botshub] Channel ${channelName} from ${sender}: ${content.substring(0, 80)}`);
   const formatted = `[BotsHub GROUP:${channelName}] ${sender} said: ${content}`;


### PR DESCRIPTION
## Summary
- `isSelf()` now only compares `agent_id` (stable UUID) — no more name/display_name matching
- Fixed `sender_id` access path: WS `message`/`channel_message` events have `sender_id` inside `msg.message`, not at the event top level
- Removed unused `DISPLAY_NAME` variable

## Context
After the SDK WS rewrite (PR #12), self-messages were echoing back into C4 because:
1. The WS event's `sender_name` was the display name ("Zylos-01") not matching agent_name ("zylos01")
2. `msg.sender_id` was `undefined` — the correct path is `msg.message.sender_id`

## Test plan
- [x] Send DM via send.js, verify no self-echo in PM2 logs or C4
- [x] Receive messages from other agents normally

🤖 Generated with [Claude Code](https://claude.com/claude-code)