### PR TITLE
rename: BotsHub → HXA-Connect

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## [0.4.0] - 2026-02-24
 
 ### Changed
-- **SDK upgrade to Phase 4 GA**: Updated botshub-sdk with auto-reconnect, ThreadContext, and protocol updates
+- **SDK upgrade to Phase 4 GA**: Updated hxa-connect-sdk with auto-reconnect, ThreadContext, and protocol updates
 - **Thread tags**: Thread `type` replaced with `tags` array — thread_created handler updated accordingly
 - **Participant events enriched**: thread_participant events now include `bot_name`, `by` (inviter), and `label` fields
 
@@ -21,14 +21,14 @@
 ## [0.3.0] - 2026-02-22
 
 ### Added
-- **botshub-sdk integration**: Outbound messages sent via SDK instead of raw curl
+- **hxa-connect-sdk integration**: Outbound messages sent via SDK instead of raw curl
 - **Thread event handling**: thread_created, thread_message, thread_updated, thread_artifact, thread_participant events forwarded to C4
 - **Thread message sending**: `send.js thread:<id> "message"` for thread replies
 - **Agent presence logging**: agent_online/agent_offline events logged
 - **Shared env module**: DRY config/env loading across bot.js and send.js
 
 ### Changed
-- send.js rewritten to use BotsHubClient SDK (replaces curl/execSync)
+- send.js rewritten to use HxaConnectClient SDK (replaces curl/execSync)
 - bot.js refactored with switch-based event dispatch
 - WebSocket token URL-encoded for safety
 - Version bumped to 0.3.0
@@ -37,7 +37,7 @@
 
 ### Changed
 - Post-install auto-registers agent using org API key — no manual agent_token needed
-- Config schema: replaced `agent_token` + `hub_url` + `agent_name` with `BOTSHUB_ORG_KEY` + `BOTSHUB_URL` + `BOTSHUB_AGENT_NAME`
+- Config schema: replaced `agent_token` + `hub_url` + `agent_name` with `HXA_CONNECT_ORG_KEY` + `HXA_CONNECT_URL` + `HXA_CONNECT_AGENT_NAME`
 - Unified to single `agent_name` identifier (display_name removed)
 
 ### Added
@@ -57,11 +57,11 @@
 ## [0.1.0] - 2026-02-15
 
 ### Added
-- WebSocket transport for BotsHub connectivity
+- WebSocket transport for HXA-Connect connectivity
 - Auto-reconnect with exponential backoff
 - C4 bridge integration for message forwarding
 - HTTPS proxy support for restricted networks
 - DM and group channel message handling
-- Outbound send script via BotsHub REST API
+- Outbound send script via HXA-Connect REST API
 - PM2 service configuration
 - Post-install and post-upgrade hooks

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-# zylos-botshub
+# zylos-hxa-connect
 
-BotsHub communication component for Zylos agents. Connects to a [BotsHub](https://github.com/coco-xyz/bots-hub) messaging hub via WebSocket, enabling agent-to-agent communication.
+HXA-Connect communication component for Zylos bots. Connects to an [HXA-Connect](https://github.com/coco-xyz/hxa-connect) messaging hub via WebSocket, enabling bot-to-bot communication.
 
 ## Features
 
@@ -11,28 +11,28 @@ BotsHub communication component for Zylos agents. Connects to a [BotsHub](https:
 
 ## Setup
 
-### 1. Register on BotsHub
+### 1. Register on HXA-Connect
 
 Get an org ID and registration ticket from your org admin, then register:
 
 ```bash
 curl -sf -X POST ${HUB_URL}/api/auth/register \
   -H "Content-Type: application/json" \
-  -d '{"org_id": "YOUR_ORG_ID", "ticket": "YOUR_TICKET", "name": "my-agent"}'
+  -d '{"org_id": "YOUR_ORG_ID", "ticket": "YOUR_TICKET", "name": "my-bot"}'
 ```
 
 Save the returned `token`.
 
 ### 2. Create config
 
-Create `~/zylos/components/botshub/config.json`:
+Create `~/zylos/components/hxa-connect/config.json`:
 
 ```json
 {
   "hub_url": "https://your-hub.example.com/hub",
   "agent_id": "your-agent-id",
   "agent_token": "agent_your_token_here",
-  "agent_name": "my-agent"
+  "agent_name": "my-bot"
 }
 ```
 
@@ -53,12 +53,12 @@ pm2 save
 
 Via C4 bridge:
 ```bash
-node ~/zylos/.claude/skills/comm-bridge/scripts/c4-send.js "botshub" "<agent_name>" "message"
+node ~/zylos/.claude/skills/comm-bridge/scripts/c4-send.js "hxa-connect" "<bot_name>" "message"
 ```
 
 Directly:
 ```bash
-node scripts/send.js <agent_name> "message"
+node scripts/send.js <bot_name> "message"
 ```
 
 ## Environment

--- a/SKILL.md
+++ b/SKILL.md
@@ -1,7 +1,7 @@
 ---
-name: botshub
+name: hxa-connect
 version: 0.4.0
-description: BotsHub agent-to-agent communication channel via WebSocket. Use when replying to BotsHub messages or sending messages to other agents.
+description: HXA-Connect bot-to-bot communication channel via WebSocket. Use when replying to HXA-Connect messages or sending messages to other bots.
 type: communication
 user-invocable: false
 
@@ -9,9 +9,9 @@ lifecycle:
   npm: true
   service:
     type: pm2
-    name: zylos-botshub
+    name: zylos-hxa-connect
     entry: src/bot.js
-  data_dir: ~/zylos/components/botshub
+  data_dir: ~/zylos/components/hxa-connect
   hooks:
     post-install: hooks/post-install.js
     post-upgrade: hooks/post-upgrade.js
@@ -20,21 +20,21 @@ lifecycle:
     - logs/
 
 upgrade:
-  repo: coco-xyz/zylos-botshub
+  repo: coco-xyz/zylos-hxa-connect
   branch: main
 
 config:
   required:
-    - name: BOTSHUB_URL
-      description: BotsHub hub URL (e.g. https://your-hub.example.com/hub)
+    - name: HXA_CONNECT_URL
+      description: HXA-Connect hub URL (e.g. https://your-hub.example.com/hub)
       sensitive: false
-    - name: BOTSHUB_AGENT_NAME
-      description: Agent name (unique identifier within the org)
+    - name: HXA_CONNECT_AGENT_NAME
+      description: Bot name (unique identifier within the org)
       sensitive: false
-    - name: BOTSHUB_ORG_ID
-      description: Organization ID for agent registration and multi-org API calls
+    - name: HXA_CONNECT_ORG_ID
+      description: Organization ID for bot registration and multi-org API calls
       sensitive: false
-    - name: BOTSHUB_ORG_TICKET
+    - name: HXA_CONNECT_ORG_TICKET
       description: One-time registration ticket (created by org admin via Web UI or API)
       sensitive: true
 
@@ -42,19 +42,19 @@ dependencies:
   - comm-bridge
 ---
 
-# BotsHub Channel
+# HXA-Connect Channel
 
-Agent-to-agent communication via BotsHub — a messaging hub for AI agents.
+Bot-to-bot communication via HXA-Connect — a messaging hub for AI bots.
 
 ## Dependencies
 
 - **comm-bridge**: Required for forwarding messages to Claude via C4 protocol
-- **botshub-sdk**: TypeScript SDK for BotsHub B2B Protocol (installed via npm)
+- **hxa-connect-sdk**: TypeScript SDK for HXA-Connect B2B Protocol (installed via npm)
 
 ## When to Use
 
-- Replying to messages from other agents on BotsHub
-- Sending messages to specific agents
+- Replying to messages from other bots on HXA-Connect
+- Sending messages to specific bots
 - Working with collaboration threads (create, message, artifacts)
 - Checking who's online
 
@@ -62,47 +62,47 @@ Agent-to-agent communication via BotsHub — a messaging hub for AI agents.
 
 Via C4 Bridge:
 ```bash
-node ~/zylos/.claude/skills/comm-bridge/scripts/c4-send.js "botshub" "<agent_name>" "message"
+node ~/zylos/.claude/skills/comm-bridge/scripts/c4-send.js "hxa-connect" "<bot_name>" "message"
 ```
 
 Or directly:
 ```bash
-node ~/zylos/.claude/skills/botshub/scripts/send.js <agent_name> "message"
+node ~/zylos/.claude/skills/hxa-connect/scripts/send.js <bot_name> "message"
 ```
 
 ## How to Send Thread Messages
 
 ```bash
-node ~/zylos/.claude/skills/botshub/scripts/send.js thread:<thread_id> "message"
+node ~/zylos/.claude/skills/hxa-connect/scripts/send.js thread:<thread_id> "message"
 ```
 
 Or via C4 Bridge:
 ```bash
-node ~/zylos/.claude/skills/comm-bridge/scripts/c4-send.js "botshub" "thread:<thread_id>" "message"
+node ~/zylos/.claude/skills/comm-bridge/scripts/c4-send.js "hxa-connect" "thread:<thread_id>" "message"
 ```
 
 ## Config Location
 
-- Config: `~/zylos/components/botshub/config.json`
-- Logs: `~/zylos/components/botshub/logs/`
+- Config: `~/zylos/components/hxa-connect/config.json`
+- Logs: `~/zylos/components/hxa-connect/logs/`
 
 ## Service Management
 
 ```bash
-pm2 status zylos-botshub
-pm2 logs zylos-botshub
-pm2 restart zylos-botshub
+pm2 status zylos-hxa-connect
+pm2 logs zylos-hxa-connect
+pm2 restart zylos-hxa-connect
 ```
 
 ## Message Format
 
 Incoming messages appear as:
 ```
-[BotsHub DM] agent-name said: message content
-[BotsHub GROUP:channel-name] agent-name said: message content
-[BotsHub Thread] New thread created: "topic" (type: request, id: uuid)
-[BotsHub Thread:uuid] agent-name said: message content
-[BotsHub Thread:uuid] Thread "topic" updated: status (status: resolved)
-[BotsHub Thread:uuid] Artifact added: "title" (type: markdown)
-[BotsHub Thread:uuid] agent-name joined the thread
+[HXA-Connect DM] bot-name said: message content
+[HXA-Connect GROUP:channel-name] bot-name said: message content
+[HXA-Connect Thread] New thread created: "topic" (tags: request, id: uuid)
+[HXA-Connect Thread:uuid] bot-name said: message content
+[HXA-Connect Thread:uuid] Thread "topic" updated: status (status: resolved)
+[HXA-Connect Thread:uuid] Artifact added: "title" (type: markdown)
+[HXA-Connect Thread:uuid] bot-name joined the thread
 ```

--- a/ecosystem.config.cjs
+++ b/ecosystem.config.cjs
@@ -3,17 +3,17 @@ const os = require('os');
 
 module.exports = {
   apps: [{
-    name: 'zylos-botshub',
+    name: 'zylos-hxa-connect',
     script: 'src/bot.js',
-    cwd: path.join(os.homedir(), 'zylos/.claude/skills/botshub'),
+    cwd: path.join(os.homedir(), 'zylos/.claude/skills/hxa-connect'),
     env: {
       NODE_ENV: 'production'
     },
     autorestart: true,
     max_restarts: 10,
     restart_delay: 5000,
-    error_file: path.join(os.homedir(), 'zylos/components/botshub/logs/error.log'),
-    out_file: path.join(os.homedir(), 'zylos/components/botshub/logs/out.log'),
+    error_file: path.join(os.homedir(), 'zylos/components/hxa-connect/logs/error.log'),
+    out_file: path.join(os.homedir(), 'zylos/components/hxa-connect/logs/out.log'),
     log_date_format: 'YYYY-MM-DD HH:mm:ss'
   }]
 };

--- a/hooks/post-install.js
+++ b/hooks/post-install.js
@@ -3,7 +3,7 @@ import fs from 'node:fs';
 import path from 'node:path';
 
 const HOME = process.env.HOME;
-const DATA_DIR = path.join(HOME, 'zylos/components/botshub');
+const DATA_DIR = path.join(HOME, 'zylos/components/hxa-connect');
 const ENV_PATH = path.join(HOME, 'zylos/.env');
 
 // 1. Create data subdirectories
@@ -25,10 +25,10 @@ function loadEnv() {
 }
 
 const env = loadEnv();
-const HUB_URL = env.BOTSHUB_URL || '';
-const ORG_ID = env.BOTSHUB_ORG_ID || '';
-const ORG_TICKET = env.BOTSHUB_ORG_TICKET || '';
-const AGENT_NAME = env.BOTSHUB_AGENT_NAME || '';
+const HUB_URL = env.HXA_CONNECT_URL || '';
+const ORG_ID = env.HXA_CONNECT_ORG_ID || '';
+const ORG_TICKET = env.HXA_CONNECT_ORG_TICKET || '';
+const AGENT_NAME = env.HXA_CONNECT_AGENT_NAME || '';
 const PROXY_URL = env.HTTPS_PROXY || env.HTTP_PROXY || '';
 
 // 3. Check if config already has a valid agent_token (re-install / upgrade scenario)
@@ -46,19 +46,19 @@ if (fs.existsSync(configPath)) {
 
 // 4. Validate required env vars
 if (!HUB_URL) {
-  console.error('[post-install] BOTSHUB_URL not set in .env');
+  console.error('[post-install] HXA_CONNECT_URL not set in .env');
   process.exit(1);
 }
 if (!ORG_ID) {
-  console.error('[post-install] BOTSHUB_ORG_ID not set in .env');
+  console.error('[post-install] HXA_CONNECT_ORG_ID not set in .env');
   process.exit(1);
 }
 if (!ORG_TICKET) {
-  console.error('[post-install] BOTSHUB_ORG_TICKET not set in .env');
+  console.error('[post-install] HXA_CONNECT_ORG_TICKET not set in .env');
   process.exit(1);
 }
 if (!AGENT_NAME) {
-  console.error('[post-install] BOTSHUB_AGENT_NAME not set in .env');
+  console.error('[post-install] HXA_CONNECT_AGENT_NAME not set in .env');
   process.exit(1);
 }
 

--- a/hooks/post-upgrade.js
+++ b/hooks/post-upgrade.js
@@ -2,7 +2,7 @@
 import fs from 'node:fs';
 import path from 'node:path';
 
-const configPath = path.join(process.env.HOME, 'zylos/components/botshub/config.json');
+const configPath = path.join(process.env.HOME, 'zylos/components/hxa-connect/config.json');
 
 if (fs.existsSync(configPath)) {
   const config = JSON.parse(fs.readFileSync(configPath, 'utf8'));

--- a/package.json
+++ b/package.json
@@ -1,10 +1,10 @@
 {
-  "name": "zylos-botshub",
+  "name": "zylos-hxa-connect",
   "version": "0.4.0",
   "type": "module",
   "private": true,
   "dependencies": {
-    "botshub-sdk": "github:coco-xyz/botshub-sdk",
+    "hxa-connect-sdk": "github:coco-xyz/hxa-connect-sdk",
     "https-proxy-agent": "^7.0.5",
     "undici": "^7.22.0",
     "ws": "^8.18.0"

--- a/scripts/send.js
+++ b/scripts/send.js
@@ -1,15 +1,15 @@
 #!/usr/bin/env node
 /**
- * zylos-botshub send interface
+ * zylos-hxa-connect send interface
  *
  * Usage:
  *   node send.js <to_agent> "<message>"          — Send DM
  *   node send.js thread:<thread_id> "<message>"   — Send thread message
  *
- * Called by C4 comm-bridge to send outbound messages via BotsHub SDK.
+ * Called by C4 comm-bridge to send outbound messages via HXA-Connect SDK.
  */
 
-import { BotsHubClient } from 'botshub-sdk';
+import { HxaConnectClient } from 'hxa-connect-sdk';
 import { loadConfig, setupFetchProxy, PROXY_URL } from '../src/env.js';
 
 const args = process.argv.slice(2);
@@ -30,7 +30,7 @@ if (!config.hub_url || !config.agent_token) {
 // Set up proxy for fetch before creating SDK client
 await setupFetchProxy();
 
-const client = new BotsHubClient({
+const client = new HxaConnectClient({
   url: config.hub_url,
   token: config.agent_token,
   ...(config.org_id && { orgId: config.org_id }),

--- a/src/env.js
+++ b/src/env.js
@@ -1,5 +1,5 @@
 /**
- * Shared environment and config loader for zylos-botshub.
+ * Shared environment and config loader for zylos-hxa-connect.
  * Loads .env, reads config.json, and sets up HTTP proxy for fetch().
  */
 
@@ -7,7 +7,7 @@ import fs from 'fs';
 import path from 'path';
 
 const HOME = process.env.HOME;
-const CONFIG_PATH = path.join(HOME, 'zylos/components/botshub/config.json');
+const CONFIG_PATH = path.join(HOME, 'zylos/components/hxa-connect/config.json');
 const ENV_PATH = path.join(HOME, 'zylos/.env');
 
 // Load .env into process.env (don't override existing vars)
@@ -29,13 +29,13 @@ export function loadConfig() {
   try {
     return JSON.parse(fs.readFileSync(CONFIG_PATH, 'utf8'));
   } catch (err) {
-    console.error('[botshub] Failed to load config:', err.message);
+    console.error('[hxa-connect] Failed to load config:', err.message);
     process.exit(1);
   }
 }
 
 /**
- * Set up HTTP proxy for native fetch() calls (used by botshub-sdk).
+ * Set up HTTP proxy for native fetch() calls (used by hxa-connect-sdk).
  * Must be called before any SDK HTTP operations.
  */
 export async function setupFetchProxy() {
@@ -44,6 +44,6 @@ export async function setupFetchProxy() {
     const { setGlobalDispatcher, ProxyAgent } = await import('undici');
     setGlobalDispatcher(new ProxyAgent(PROXY_URL));
   } catch {
-    console.warn('[botshub] Could not set up fetch proxy — undici not available');
+    console.warn('[hxa-connect] Could not set up fetch proxy — undici not available');
   }
 }


### PR DESCRIPTION
## Summary
- Full rename from BotsHub to HXA-Connect across all files
- Package name, SDK imports, class references, C4 channel, message format, log prefixes, PM2 service name, config/data paths, environment variables, SKILL.md, docs
- 10 files changed, zero remaining old-name references

Part of the HXA-Connect rename migration.

## Test plan
- [ ] npm install with renamed hxa-connect-sdk dependency
- [ ] Integration test on test server after hxa-connect server deployed

🤖 Generated with [Claude Code](https://claude.com/claude-code)