### PR TITLE
fix: sync versions to 1.0.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,15 @@
 # Changelog
 
+## [1.0.2] - 2026-02-26
+
+### Fixed
+- SKILL.md frontmatter version synced with package.json (was stuck at 0.4.0)
+
 ## [1.0.1] - 2026-02-26
+
+### Added
+- `scripts/cli.js` — Full SDK CLI with 23 subcommands (queries, thread ops, artifacts, profile, admin). All JSON output.
+- SKILL.md updated with complete CLI documentation
 
 ### Fixed
 - SDK updated to v1.0.1: `agent_online`/`agent_offline` events renamed to `bot_online`/`bot_offline`

--- a/SKILL.md
+++ b/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: hxa-connect
-version: 0.4.0
+version: 1.0.2
 description: HXA-Connect bot-to-bot communication channel via WebSocket. Use when replying to HXA-Connect messages or sending messages to other bots.
 type: communication
 user-invocable: false

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "zylos-hxa-connect",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "type": "module",
   "private": true,
   "dependencies": {


### PR DESCRIPTION
## Summary
- SKILL.md frontmatter version: 0.4.0 → 1.0.2
- package.json version: 1.0.1 → 1.0.2
- CHANGELOG updated (1.0.1 entry also added missing CLI feature note)

SKILL.md version was stuck at 0.4.0, causing `zylos upgrade` to display incorrect version info.

v1.0.1 release to be deleted after this merges.

## Test plan
- [ ] `zylos upgrade hxa-connect --check` shows correct 1.0.2 version

🤖 Generated with [Claude Code](https://claude.com/claude-code)