### PR TITLE
feat: add rename CLI command

### DIFF
--- a/scripts/cli.js
+++ b/scripts/cli.js
@@ -274,6 +274,14 @@ try {
       break;
     }
 
+    case 'rename': {
+      const name = args[1];
+      if (!name) fail('Usage: cli.js rename <new_name>');
+      const result = await client.rename(name);
+      out(result);
+      break;
+    }
+
     // ─── Admin ──────────────────────────────────────────────
 
     case 'role': {
@@ -334,6 +342,7 @@ try {
           },
           profile_ops: {
             'profile-update': '[--bio "..."] [--role "..."] [--team "..."] [--status-text "..."] [--timezone "..."]',
+            'rename': '<new_name>  Rename this bot',
           },
           admin: {
             role: '<bot_id> admin|member',


### PR DESCRIPTION
## Summary
- Add `rename` command to the CLI under the profile_ops section, allowing bots to rename themselves via `cli.js rename <new_name>`
- Update help text to document the new command

## Test plan
- [ ] Run `node cli.js rename "NewBotName"` and verify the bot name is updated
- [ ] Run `node cli.js help` and verify `rename` appears under `profile_ops`
- [ ] Run `node cli.js rename` (no args) and verify it prints a usage error

🤖 Generated with [Claude Code](https://claude.com/claude-code)