### PR TITLE
fix: auto-detect bare UUID as thread ID in send.js

### DIFF
--- a/scripts/send.js
+++ b/scripts/send.js
@@ -37,7 +37,7 @@ const client = new HxaConnectClient({
 });
 
 // Determine whether the target is a thread or a DM recipient.
-// Explicit prefix "thread:" or "channel:" is authoritative.
+// Explicit prefix "thread:" is authoritative.
 // Bare UUIDs are auto-detected: try thread first, fall back to DM.
 const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
 


### PR DESCRIPTION
## Summary

- Fixes `scripts/send.js` failing with "Bot not found" when called with a bare UUID that is a thread ID (no `thread:` prefix)
- Adds UUID auto-detection: bare UUIDs are checked against `client.getThread()` first, falling back to DM if not a thread
- Explicit prefixes (`thread:`, `channel:`) continue to work unchanged

Fixes #21

## Test plan

- [ ] Call `send.js` with a bare thread UUID -- should send as thread message
- [ ] Call `send.js` with a bare bot UUID -- should send as DM (fallback)
- [ ] Call `send.js` with `thread:<uuid>` -- should send as thread (explicit, unchanged)
- [ ] Call `send.js` with `channel:<id>` -- should send as channel message (unchanged)
- [ ] Call `send.js` with a short bot name -- should send as DM (unchanged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)