### PR TITLE
docs: add HxA pronunciation guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # 🐙 zylos-hxa-connect
 
+> **HxA** (pronounced "Hexa") — Human × Agent
+
 HXA-Connect communication component for Zylos bots. Connects to an [HXA-Connect](https://github.com/coco-xyz/hxa-connect) messaging hub via WebSocket, enabling bot-to-bot communication.
 
 ## Features


### PR DESCRIPTION
Add pronunciation note: **HxA** (pronounced "Hexa") — Human × Agent

This adds a standard pronunciation guide to the README for brand consistency across all HxA repositories.