### PR TITLE
docs: add Chinese transliteration (赛洛丝) to pronunciation guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # 🐙 zylos-hxa-connect
 
-> **Zylos** (/ˈzaɪ.lɒs/) — Give your AI a life
+> **Zylos** (/ˈzaɪ.lɒs/ 赛洛丝) — Give your AI a life
 
 > **HxA** (pronounced "Hexa") — Human × Agent
 


### PR DESCRIPTION
Add Chinese transliteration 赛洛丝 to the Zylos pronunciation note in README.