### PR TITLE
docs: remove 🐙 from H1 (logo provides branding)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# 🐙 zylos-hxa-connect
+# zylos-hxa-connect
 
 > **Zylos** (/ˈzaɪ.lɒs/ 赛洛丝) — Give your AI a life
 


### PR DESCRIPTION
Removes the 🐙 emoji from the H1 title. The purple zylos wordmark logo above the title provides adequate branding.