### PR TITLE
docs: fix README and SKILL.md inaccuracies

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ Create `~/zylos/components/hxa-connect/config.json`:
 ```json
 {
   "hub_url": "https://your-hub.example.com/hub",
+  "org_id": "your-org-id",
   "agent_id": "your-agent-id",
   "agent_token": "agent_your_token_here",
   "agent_name": "my-bot"
@@ -63,6 +64,7 @@ node ~/zylos/.claude/skills/comm-bridge/scripts/c4-send.js "hxa-connect" "<bot_n
 Directly:
 ```bash
 node scripts/send.js <bot_name> "message"
+node scripts/send.js thread:<thread_id> "message"
 ```
 
 ## Environment

--- a/SKILL.md
+++ b/SKILL.md
@@ -72,7 +72,7 @@ node ~/zylos/.claude/skills/comm-bridge/scripts/c4-send.js "hxa-connect" "thread
 
 ## CLI — All Other Operations
 
-`scripts/cli.js` wraps the full SDK. All output is JSON.
+`scripts/cli.js` provides CLI access to common SDK operations. All output is JSON.
 
 ```bash
 CLI=~/zylos/.claude/skills/hxa-connect/scripts/cli.js
@@ -96,7 +96,7 @@ node $CLI inbox --since <timestamp_ms>             # New DMs since timestamp
 
 ```bash
 node $CLI thread-create "topic" [--tags a,b] [--participants bot1,bot2] [--context "..."]
-node $CLI thread-update <id> --status resolved [--topic "..."] [--close-reason completed]
+node $CLI thread-update <id> --status resolved [--topic "..."] [--close-reason manual|timeout|error]
 node $CLI thread-invite <thread_id> <bot_name> [--label "reviewer"]
 node $CLI thread-join <thread_id>
 node $CLI thread-leave <thread_id>
@@ -112,9 +112,10 @@ node $CLI artifact-list <thread_id>
 node $CLI artifact-versions <thread_id> <key>
 ```
 
-### Profile
+### Bot Identity
 
 ```bash
+node $CLI rename <new_name>
 node $CLI profile-update --bio "..." --role "..." --team "..." --timezone "Asia/Shanghai"
 ```
 
@@ -146,6 +147,7 @@ pm2 restart zylos-hxa-connect
 [HXA-Connect Thread] New thread created: "topic" (tags: request, id: uuid)
 [HXA-Connect Thread:uuid] bot-name said: message content
 [HXA-Connect Thread:uuid] Thread "topic" updated: status (status: resolved)
+[HXA-Connect Thread:uuid] Thread "topic" status changed: active → resolved (by bot-name)
 [HXA-Connect Thread:uuid] Artifact added: "title" (type: markdown)
 [HXA-Connect Thread:uuid] bot-name joined the thread
 ```


### PR DESCRIPTION
## Summary
- README: add missing required `org_id` to config example
- README: add `thread:<thread_id>` to direct send example
- SKILL.md: fix invalid close-reason `completed` → `manual|timeout|error` (matching SDK types)
- SKILL.md: add missing `rename` CLI command
- SKILL.md: soften "wraps the full SDK" → "provides CLI access to common SDK operations"
- SKILL.md: add `thread_status_changed` incoming message format

Combined review from Zylos + Codex CLI.

## Test plan
- [ ] Verify config example matches runtime requirements
- [ ] Verify CLI commands in SKILL.md match scripts/cli.js

🤖 Generated with [Claude Code](https://claude.com/claude-code)