### PR TITLE
fix: allow human-authored messages through self-message filter

### DIFF
--- a/src/bot.js
+++ b/src/bot.js
@@ -112,14 +112,22 @@ for (const [label, org] of Object.entries(resolved.orgs)) {
     },
   });
 
-  const isSelf = (id) => org.agentId && id === org.agentId;
+  const isSelf = (id, metadata) => {
+    if (!org.agentId || id !== org.agentId) return false;
+    // Human-authored messages via Web UI should not be treated as self-echo
+    const meta = typeof metadata === 'string'
+      ? (() => { try { return JSON.parse(metadata); } catch { return null; } })()
+      : metadata;
+    if (meta?.provenance?.authored_by === 'human') return false;
+    return true;
+  };
 
   // ─── Event Handlers ───────────────────────────────────
 
   client.on('message', (msg) => {
     const sender = msg.sender_name || 'unknown';
     const content = msg.message?.content || msg.content || '';
-    if (isSelf(msg.message?.sender_id)) return;
+    if (isSelf(msg.message?.sender_id, msg.message?.metadata)) return;
 
     if (!isDmAllowed(org.access, sender)) {
       console.log(`${lp} DM from ${sender} rejected (dmPolicy: ${org.access?.dmPolicy || 'open'})`);
@@ -203,7 +211,7 @@ for (const [label, org] of Object.entries(resolved.orgs)) {
 
   client.on('thread_message', (msg) => {
     const message = msg.message || {};
-    if (isSelf(message.sender_id)) return;
+    if (isSelf(message.sender_id, message.metadata)) return;
     const sender = message.sender_name || message.sender_id || 'unknown';
     const content = message.content || '';
     console.log(`${lp} Thread ${msg.thread_id} from ${sender} (buffered): ${content.substring(0, 80)}`);


### PR DESCRIPTION
## Summary
- `isSelf()` was dropping all messages where `sender_id` matches the bot's own agent ID, including messages sent by a human org admin via the Web UI (which uses the bot's token)
- Now checks `metadata.provenance.authored_by`: if `'human'`, the message is allowed through
- Applied to DM handler and thread message log handler
- The primary thread delivery path goes through the SDK's ThreadContext — companion fix: coco-xyz/hxa-connect-sdk#22

## Test plan
- [x] Deployed locally with patched code, confirmed Web UI thread messages now reach the bot
- [ ] Verify bot's own programmatic messages are still filtered (no echo loop)
- [ ] Verify DM messages from Web UI also work

🤖 Generated with [Claude Code](https://claude.com/claude-code)