### PR TITLE
feat: per-org enabled flag

### DIFF
--- a/src/env.js
+++ b/src/env.js
@@ -161,6 +161,10 @@ export function resolveOrgs(config) {
       console.error(`[hxa-connect] Skipping org "${label}" — invalid label (must match /^[a-z0-9][a-z0-9-]*$/)`);
       continue;
     }
+    if (org.enabled === false) {
+      console.log(`[hxa-connect] Org "${label}" disabled — skipping`);
+      continue;
+    }
     if (!org.org_id || !org.agent_token || !org.agent_name) {
       const missing = [!org.org_id && 'org_id', !org.agent_token && 'agent_token', !org.agent_name && 'agent_name'].filter(Boolean);
       console.error(`[hxa-connect] Skipping org "${label}" — missing: ${missing.join(', ')}`);


### PR DESCRIPTION
## Summary
- Adds `enabled` field to per-org config in `resolveOrgs()`
- When `enabled: false`, the org is skipped with a log message
- Orgs without the field default to enabled (backwards compatible)

## Usage
```json
{
  "orgs": {
    "coco": { "org_id": "...", "enabled": true, ... },
    "sparten": { "org_id": "...", "enabled": false, ... }
  }
}
```

Set `"enabled": false` on any org to keep it in config but not connect. Restart the PM2 service to apply.

## Test plan
- [ ] Verify org with `enabled: false` is skipped (log: `Org "x" disabled — skipping`)
- [ ] Verify org without `enabled` field still connects normally
- [ ] Verify org with `enabled: true` connects normally

🤖 Generated with [Claude Code](https://claude.com/claude-code)