### PR TITLE
docs: document per-org enabled flag

### DIFF
--- a/SKILL.md
+++ b/SKILL.md
@@ -177,6 +177,21 @@ node $ADM --org coco set-dm-policy allowlist
 node $ADM --org acme set-group-policy disabled
 ```
 
+### Per-Org Enable/Disable
+
+Set `"enabled": false` on any org to keep it in config but skip its connection:
+
+```json
+{
+  "orgs": {
+    "coco": { "org_id": "...", "agent_token": "...", "agent_name": "..." },
+    "acme": { "org_id": "...", "agent_token": "...", "agent_name": "...", "enabled": false }
+  }
+}
+```
+
+Orgs without the `enabled` field (or with `"enabled": true`) connect normally. Restart the service to apply changes.
+
 ### Admin CLI
 
 ```bash


### PR DESCRIPTION
## Summary
- Adds documentation for the `enabled` per-org config option to SKILL.md
- Shows config example with `"enabled": false` to skip an org's connection

Follows up on PR #44 which added the feature.

🤖 Generated with [Claude Code](https://claude.com/claude-code)