### PR TITLE
feat: explicitly write enabled field to org config

### DIFF
--- a/src/env.js
+++ b/src/env.js
@@ -98,6 +98,7 @@ export function migrateConfig() {
     config.default_hub_url = hub_url || null;
     config.orgs = {
       default: {
+        enabled: true,
         org_id,
         agent_id: agent_id || null,
         agent_token,
@@ -134,6 +135,14 @@ export function migrateConfig() {
       delete config[key];
     }
     changed = true;
+  }
+
+  // Phase 3: backfill explicit enabled field
+  for (const org of Object.values(config.orgs)) {
+    if (!('enabled' in org)) {
+      org.enabled = true;
+      changed = true;
+    }
   }
 
   if (changed) {


### PR DESCRIPTION
## Summary
- Phase 1 migration: new org entries now include `enabled: true` explicitly
- Phase 3 migration (new): backfills `enabled: true` for existing orgs missing the field
- After migration, every org in config.json will have a visible `enabled` field

This ensures the field is always explicit — no need to guess whether a missing field means "enabled" or not.

## Test plan
- [ ] Fresh single-org config migrates with `enabled: true` in the default org
- [ ] Existing multi-org config without `enabled` fields gets backfilled on next startup
- [ ] Orgs with `enabled: false` are preserved (not overwritten to true)

🤖 Generated with [Claude Code](https://claude.com/claude-code)