### PR TITLE
chore: v1.4.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,21 @@
 # Changelog
 
+## [1.4.0] - 2026-03-04
+
+### Added
+- **Per-org enabled flag**: Selectively disable individual orgs without removing config (`enabled: false`)
+- **Explicit enabled field migration**: Phase 3 migration auto-adds `enabled: true` to existing orgs missing the field; new orgs default to `enabled: true`
+- **SDK session_invalidated handling**: Handles 4002 close code — logs event and exits for PM2 restart
+- `ack` added to HANDLED_EVENTS set
+- SKILL.md updated with per-org enabled flag documentation
+
+### Changed
+- Thread message formatting uses XML tags instead of plain-text markers
+- SDK dependency bumped to `^1.2.0` (session_invalidated event support)
+
+### Fixed
+- Self-message filter now allows human-authored messages through (was incorrectly blocking)
+
 ## [1.3.1] - 2026-03-02
 
 ### Changed

--- a/SKILL.md
+++ b/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: hxa-connect
-version: 1.3.1
+version: 1.4.0
 description: HXA-Connect bot-to-bot communication channel via WebSocket. Use when replying to HXA-Connect messages or sending messages to other bots.
 type: communication
 user-invocable: false

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "zylos-hxa-connect",
-  "version": "1.3.0",
+  "version": "1.4.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "zylos-hxa-connect",
-      "version": "1.3.0",
+      "version": "1.4.0",
       "dependencies": {
         "@coco-xyz/hxa-connect-sdk": "^1.1.1",
         "https-proxy-agent": "^7.0.5",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "zylos-hxa-connect",
-  "version": "1.3.1",
+  "version": "1.4.0",
   "type": "module",
   "private": true,
   "dependencies": {


### PR DESCRIPTION
## Summary
- Bump version to 1.4.0
- Updated package.json, package-lock.json, SKILL.md, CHANGELOG.md

### Changes since v1.3.1
- **Per-org enabled flag** (#44): Selectively disable individual orgs without removing config
- **Explicit enabled field migration** (#46): Phase 3 auto-adds `enabled: true` to existing orgs
- **SDK session_invalidated handling** (#43): Handles 4002 close code for PM2 restart
- **XML thread formatting** (#42): Thread messages use XML tags
- **Self-message filter fix** (#41): Allow human-authored messages through
- **SKILL.md docs** (#45): Per-org enabled flag documentation
- **Release process guidelines** (#40): Added to CLAUDE.md

🤖 Generated with [Claude Code](https://claude.com/claude-code)