### PR TITLE
fix: bump hxa-connect-sdk minimum to ^1.2.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,16 +8,16 @@
       "name": "zylos-hxa-connect",
       "version": "1.4.1",
       "dependencies": {
-        "@coco-xyz/hxa-connect-sdk": "^1.1.1",
+        "@coco-xyz/hxa-connect-sdk": "^1.2.0",
         "https-proxy-agent": "^7.0.5",
         "undici": "^7.22.0",
         "ws": "^8.18.0"
       }
     },
     "node_modules/@coco-xyz/hxa-connect-sdk": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/@coco-xyz/hxa-connect-sdk/-/hxa-connect-sdk-1.1.1.tgz",
-      "integrity": "sha512-03yDGef3zoXVYMilxgj/+AbvNvnyzjoykqIKsmvV3PIe8NXHCo6hOC0bOBoLIxTtsS/aNP6aH1HEwuyqsZ+h6w==",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@coco-xyz/hxa-connect-sdk/-/hxa-connect-sdk-1.2.0.tgz",
+      "integrity": "sha512-szD3HPJS0Je2tmUOX0RdpvuV6/UowhANYQD72kGJ0LjPiGIMzEz6lpv28UC5gIjQpJMFjJu+zeJ9OyTXzT88bg==",
       "license": "MIT",
       "dependencies": {
         "ws": "^8.18.0"

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "type": "module",
   "private": true,
   "dependencies": {
-    "@coco-xyz/hxa-connect-sdk": "^1.1.1",
+    "@coco-xyz/hxa-connect-sdk": "^1.2.0",
     "https-proxy-agent": "^7.0.5",
     "undici": "^7.22.0",
     "ws": "^8.18.0"


### PR DESCRIPTION
## Summary
- Bump `@coco-xyz/hxa-connect-sdk` from `^1.1.1` to `^1.2.0` in package.json
- v1.4.0+ code depends on SDK v1.2.0 features (`session_invalidated` event, human provenance bypass in `ThreadContext`)
- The old range `^1.1.1` would resolve to 1.2.0 in practice, but a locked install at 1.1.x would break at runtime

## Test plan
- [ ] Verify `npm install` resolves to SDK 1.2.0
- [ ] Verify bot connects and handles messages normally after install

🤖 Generated with [Claude Code](https://claude.com/claude-code)