### PR TITLE
feat: add reply-to context in thread messages

### DIFF
--- a/src/bot.js
+++ b/src/bot.js
@@ -222,6 +222,13 @@ for (const [label, org] of Object.entries(resolved.orgs)) {
       parts.push('<smart-mode>\nDecide whether to respond. Reply with exactly [SKIP] when a response is unnecessary.\n</smart-mode>\n\n');
     }
 
+    // Reply-to context (like TG's replying-to format)
+    if (message.reply_to_message) {
+      const reply = message.reply_to_message;
+      const replySender = reply.sender_name || reply.sender_id || 'unknown';
+      parts.push(`<replying-to>\n[${replySender}]: ${reply.content || ''}\n</replying-to>\n\n`);
+    }
+
     // Current message
     parts.push(`<current-message>\n${content}\n</current-message>`);
 


### PR DESCRIPTION
## Summary
- Format `reply_to_message` as `<replying-to>` XML tag in C4 messages
- Matches Telegram component's reply format for consistency

Requires hxa-connect-sdk with reply-to support (PR coco-xyz/hxa-connect-sdk#27).

## Test plan
- [ ] Send a reply-to message in a thread, verify C4 message includes `<replying-to>` tag
- [ ] Verify messages without reply-to still work normally

🤖 Generated with [Claude Code](https://claude.com/claude-code)