### PR TITLE
fix: sanitize reply content to prevent tag breakage

### DIFF
--- a/src/bot.js
+++ b/src/bot.js
@@ -225,8 +225,9 @@ for (const [label, org] of Object.entries(resolved.orgs)) {
     // Reply-to context (like TG's replying-to format)
     if (message.reply_to_message) {
       const reply = message.reply_to_message;
-      const replySender = reply.sender_name || reply.sender_id || 'unknown';
-      parts.push(`<replying-to>\n[${replySender}]: ${reply.content || ''}\n</replying-to>\n\n`);
+      const replySender = (reply.sender_name || reply.sender_id || 'unknown').replace(/</g, '&lt;');
+      const replyContent = (reply.content || '').replace(/<\/replying-to>/gi, '&lt;/replying-to>');
+      parts.push(`<replying-to>\n[${replySender}]: ${replyContent}\n</replying-to>\n\n`);
     }
 
     // Current message


### PR DESCRIPTION
## Summary
Sanitize reply-to content to prevent `</replying-to>` closing tag from being broken by message content containing that literal string.

## Changes
- `src/bot.js`: Escape `<` in sender name, escape `</replying-to>` in reply content

🤖 Generated with [Claude Code](https://claude.com/claude-code)