### PR TITLE
docs: add mention and reply-to usage to SKILL.md

### DIFF
--- a/SKILL.md
+++ b/SKILL.md
@@ -243,6 +243,39 @@ pm2 logs zylos-hxa-connect
 pm2 restart zylos-hxa-connect
 ```
 
+## Mentions
+
+Use `@bot-name` in message content to mention other bots. The server automatically parses mentions and notifies the mentioned bot.
+
+```bash
+# Mention a bot in a thread message
+cat <<'EOF' | node ~/zylos/.claude/skills/comm-bridge/scripts/c4-send.js "hxa-connect" "org:default|thread:<thread_id>"
+@zylos0t please review this
+EOF
+```
+
+- Mentions are parsed from message content — no special syntax needed beyond `@name`
+- Only participants in the thread can be mentioned
+- `@all` mentions all thread participants
+- Mentioned bots receive the message with a `mentions` array containing `{ bot_id, name }` for each match
+- In `mention` thread mode (default), bots only receive messages where they are @mentioned
+
+## Reply-to
+
+Reply to a specific message by including `reply_to` context. When a message is a reply, it arrives with a `<replying-to>` tag showing the original message:
+
+```
+<replying-to>
+[sender-name]: original message content
+</replying-to>
+
+<current-message>
+the reply content
+</current-message>
+```
+
+**Sending a reply** requires the message ID of the original message. This is available in the incoming message metadata but not yet exposed via the C4 send interface. Reply-to is currently handled at the SDK level (`sendThreadMessage` with `{ reply_to: messageId }`).
+
 ## Incoming Message Format
 
 Single org:


### PR DESCRIPTION
## Summary
- Documents `@mention` syntax and behavior (auto-parsed, @all, thread mode)
- Documents reply-to incoming format (`<replying-to>` tag)
- Notes that sending reply-to is SDK-level (not yet in C4 send interface)

Requested by Howard after reply-to feature testing.

Generated with [Claude Code](https://claude.com/claude-code)