### PR TITLE
feat: auto reply-to trigger message on send

### DIFF
--- a/scripts/send.js
+++ b/scripts/send.js
@@ -91,6 +91,7 @@ const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/
 
 async function sendAsThread(threadId) {
   const opts = replyToId ? { reply_to: replyToId } : undefined;
+  let usedReplyTo = !!replyToId;
   try {
     await client.sendThreadMessage(threadId, message, opts);
   } catch (err) {
@@ -98,11 +99,12 @@ async function sendAsThread(threadId) {
     if (replyToId && (err?.status === 400 || err?.body?.code === 'NOT_FOUND')) {
       console.warn(`[hxa-connect] reply_to ${replyToId} failed, sending without reply`);
       await client.sendThreadMessage(threadId, message);
+      usedReplyTo = false;
     } else {
       throw err;
     }
   }
-  console.log(`Sent to thread ${threadId}${replyToId ? ` (reply_to: ${replyToId})` : ''}: ${message.substring(0, 50)}...`);
+  console.log(`Sent to thread ${threadId}${usedReplyTo ? ` (reply_to: ${replyToId})` : ''}: ${message.substring(0, 50)}...`);
 }
 
 async function sendAsDM(to) {

--- a/src/bot.js
+++ b/src/bot.js
@@ -226,7 +226,7 @@ for (const [label, org] of Object.entries(resolved.orgs)) {
     if (message.reply_to_message) {
       const reply = message.reply_to_message;
       const replySender = (reply.sender_name || reply.sender_id || 'unknown').replace(/</g, '&lt;');
-      const replyContent = (reply.content || '').replace(/<\/replying-to>/gi, '&lt;/replying-to>');
+      const replyContent = (reply.content || '').replace(/<\/replying-to\s*>/gi, '&lt;/replying-to>');
       parts.push(`<replying-to>\n[${replySender}]: ${replyContent}\n</replying-to>\n\n`);
     }
 


### PR DESCRIPTION
## Summary
- Encode trigger message ID in C4 endpoint (`msg:<id>` suffix) so outbound replies automatically reply-to the triggering message
- Parse `msg:<id>` in send.js and pass `reply_to` option to SDK's `sendThreadMessage()`
- Graceful fallback: if reply_to fails (message deleted/too old), retry without it

Mirrors zylos-telegram's reply-to behavior for consistent UX across channels.

**Dependency:** Requires hxa-connect-sdk >= 1.3.0 (PR #27 merged, npm release pending).

## Test plan
- [x] Tested on production (test org thread d9d270b6): Howard @zylos0t triggers reply, response auto reply-to's his message
- [ ] Codex review

🤖 Generated with [Claude Code](https://claude.com/claude-code)