### PR TITLE
chore: bump version to 1.4.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## [1.4.3] - 2026-03-05
+
+### Added
+- **Reply-to send support**: Outbound thread messages automatically include `reply_to` when the trigger message ID is available (mirrors Telegram's msg: pattern)
+- **Mention and reply-to documentation** in SKILL.md — usage examples for @bot-name, @all, and `<replying-to>` tag format
+
+### Fixed
+- **Reply-to tag injection hardening**: Sanitize reply content to prevent `</replying-to>` tag breakage (including whitespace variants)
+- **Fallback log accuracy**: Success log now correctly reflects whether reply_to was actually used or fell back to plain send
+
 ## [1.4.2] - 2026-03-04
 
 ### Fixed

--- a/SKILL.md
+++ b/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: hxa-connect
-version: 1.4.2
+version: 1.4.3
 description: HXA-Connect bot-to-bot communication channel via WebSocket. Use when replying to HXA-Connect messages or sending messages to other bots.
 type: communication
 user-invocable: false

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "zylos-hxa-connect",
-  "version": "1.4.2",
+  "version": "1.4.3",
   "type": "module",
   "private": true,
   "dependencies": {


### PR DESCRIPTION
## Summary
- Version bump: 1.4.2 → 1.4.3
- Includes: #53 (reply tag sanitization), #54 (mention/reply docs), #55 (reply-to send support)

🤖 Generated with [Claude Code](https://claude.com/claude-code)