### PR TITLE
fix: security hardening — Sprint 1 (#58 #59 #60)

### DIFF
--- a/src/admin.js
+++ b/src/admin.js
@@ -62,7 +62,15 @@ function getOrgAccess(config, label) {
 
 const commands = {
   show: (config) => {
-    console.log(JSON.stringify(config, null, 2));
+    const redacted = JSON.parse(JSON.stringify(config));
+    if (redacted.orgs) {
+      for (const org of Object.values(redacted.orgs)) {
+        if (org.agent_token) {
+          org.agent_token = org.agent_token.slice(0, 4) + '***';
+        }
+      }
+    }
+    console.log(JSON.stringify(redacted, null, 2));
   },
 
   // ─── DM Policy ─────────────────────────────────────────

--- a/src/bot.js
+++ b/src/bot.js
@@ -41,7 +41,13 @@ function logPrefix(label) {
 
 await setupFetchProxy();
 
-const wsOptions = PROXY_URL ? { agent: new HttpsProxyAgent(PROXY_URL) } : undefined;
+const MAX_WS_PAYLOAD = 1048576; // 1 MB
+const MAX_CONTENT_LENGTH = 51200; // 50 KB
+
+const wsOptions = {
+  maxPayload: MAX_WS_PAYLOAD,
+  ...(PROXY_URL ? { agent: new HttpsProxyAgent(PROXY_URL) } : {}),
+};
 
 // ─── C4 Bridge ─────────────────────────────────────────────
 
@@ -97,7 +103,8 @@ for (const [label, org] of Object.entries(resolved.orgs)) {
   }
 
   if (!org.agentId) {
-    console.warn(`${lp} agent_id not set — self-message filter may be incomplete`);
+    console.error(`${lp} agent_id is required — without it, isSelf() cannot filter self-messages. Set agent_id in config.json for org "${label}"`);
+    continue;
   }
 
   const client = new HxaConnectClient({
@@ -129,6 +136,11 @@ for (const [label, org] of Object.entries(resolved.orgs)) {
     const sender = msg.sender_name || 'unknown';
     const content = msg.message?.content || msg.content || '';
     if (isSelf(msg.message?.sender_id, msg.message?.metadata)) return;
+
+    if (content.length > MAX_CONTENT_LENGTH) {
+      console.warn(`${lp} DM from ${sender} rejected — content too large (${content.length} bytes)`);
+      return;
+    }
 
     if (!isDmAllowed(org.access, sender)) {
       console.log(`${lp} DM from ${sender} rejected (dmPolicy: ${org.access?.dmPolicy || 'open'})`);
@@ -194,6 +206,11 @@ for (const [label, org] of Object.entries(resolved.orgs)) {
   threadCtx.onMention(({ threadId, message, snapshot }) => {
     const sender = msgSender(message);
     const content = message.content || '';
+
+    if (content.length > MAX_CONTENT_LENGTH) {
+      console.warn(`${lp} Thread ${threadId} from ${sender} rejected — content too large (${content.length} bytes)`);
+      return;
+    }
 
     // groupPolicy gates thread access (threads = group chat)
     if (!isThreadAllowed(org.access, threadId)) {

--- a/src/env.js
+++ b/src/env.js
@@ -46,7 +46,7 @@ export function loadConfig() {
 
 function atomicWrite(filePath, data) {
   const tmpPath = filePath + `.tmp.${process.pid}`;
-  fs.writeFileSync(tmpPath, JSON.stringify(data, null, 2) + '\n');
+  fs.writeFileSync(tmpPath, JSON.stringify(data, null, 2) + '\n', { mode: 0o600 });
   fs.renameSync(tmpPath, filePath);
 }
 
@@ -69,7 +69,7 @@ export function migrateConfig() {
 
     const backupPath = CONFIG_PATH + '.bak';
     if (!fs.existsSync(backupPath)) {
-      fs.writeFileSync(backupPath, JSON.stringify(config, null, 2) + '\n');
+      fs.writeFileSync(backupPath, JSON.stringify(config, null, 2) + '\n', { mode: 0o600 });
       console.log(`[hxa-connect] Backup written to ${backupPath}`);
     }
 

--- a/src/lib/config.js
+++ b/src/lib/config.js
@@ -21,7 +21,7 @@ export function loadConfig() {
 export function saveConfig(config) {
   try {
     const tmpPath = CONFIG_PATH + `.tmp.${process.pid}`;
-    fs.writeFileSync(tmpPath, JSON.stringify(config, null, 2) + '\n');
+    fs.writeFileSync(tmpPath, JSON.stringify(config, null, 2) + '\n', { mode: 0o600 });
     fs.renameSync(tmpPath, CONFIG_PATH);
     return true;
   } catch (err) {


### PR DESCRIPTION
## Summary

Addresses all 3 Sprint 1 security issues from the HxA Connect audit:

- **#58 [C-01+H-03] Critical** — Config file permissions + token redaction
  - All `writeFileSync` / `renameSync` calls now use `{ mode: 0o600 }` (owner-only)
  - Applies to: `saveConfig()`, `atomicWrite()`, migration backup
  - `admin show` redacts `agent_token` (shows first 4 chars + `***`)

- **#59 [H-01] High** — WebSocket message size limit
  - `wsOptions.maxPayload` set to 1 MB (was unlimited/100 MB default)
  - Content length check (50 KB) on DM and thread mention handlers

- **#60 [H-04] High** — `isSelf` agentId null guard
  - Org setup now skips (`continue`) when `agent_id` is missing
  - Previously only warned — `isSelf()` returned false for all messages, causing loops

## Test plan

- [ ] Verify existing config.json gets 0600 perms after any admin CLI write
- [ ] `node admin.js show` displays redacted tokens (e.g. `abc1***`)
- [ ] Bot connects normally with valid agent_id
- [ ] Bot logs error and skips org with missing agent_id (no crash loop)
- [ ] Large messages (>50 KB content) are rejected with log warning

Closes #58, closes #59, closes #60

🤖 Generated with [Claude Code](https://claude.com/claude-code)