### PR TITLE
fix(security): escape XML in thread context to prevent prompt injection

### DIFF
--- a/src/bot.js
+++ b/src/bot.js
@@ -39,6 +39,10 @@ function logPrefix(label) {
   return `[hxa-connect:${label}]`;
 }
 
+function escapeXml(str) {
+  return str.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;');
+}
+
 await setupFetchProxy();
 
 const wsOptions = PROXY_URL ? { agent: new HttpsProxyAgent(PROXY_URL) } : undefined;
@@ -213,7 +217,7 @@ for (const [label, org] of Object.entries(resolved.orgs)) {
     // Thread context: previous messages (excluding trigger)
     const contextMsgs = snapshot.newMessages.filter(m => m.id !== message.id);
     if (contextMsgs.length > 0) {
-      const lines = contextMsgs.map(m => `[${msgSender(m)}]: ${m.content || ''}`);
+      const lines = contextMsgs.map(m => `[${escapeXml(msgSender(m))}]: ${escapeXml(m.content || '')}`);
       parts.push(`<thread-context>\n${lines.join('\n')}\n</thread-context>\n\n`);
     }
 
@@ -225,13 +229,13 @@ for (const [label, org] of Object.entries(resolved.orgs)) {
     // Reply-to context (like TG's replying-to format)
     if (message.reply_to_message) {
       const reply = message.reply_to_message;
-      const replySender = (reply.sender_name || reply.sender_id || 'unknown').replace(/</g, '&lt;');
-      const replyContent = (reply.content || '').replace(/<\/replying-to\s*>/gi, '&lt;/replying-to>');
+      const replySender = escapeXml(reply.sender_name || reply.sender_id || 'unknown');
+      const replyContent = escapeXml(reply.content || '');
       parts.push(`<replying-to>\n[${replySender}]: ${replyContent}\n</replying-to>\n\n`);
     }
 
     // Current message
-    parts.push(`<current-message>\n${content}\n</current-message>`);
+    parts.push(`<current-message>\n${escapeXml(content)}\n</current-message>`);
 
     // Include trigger message ID in endpoint for reply-to on send (like TG's msg: pattern)
     const msgIdSuffix = message.id ? `|msg:${message.id}` : '';


### PR DESCRIPTION
## Summary
- Add `escapeXml()` helper to sanitize `&`, `<`, `>` in user-controlled content
- Apply to all 4 XML injection points: thread-context (sender + content), replying-to (sender + content), current-message content
- Replaces incomplete ad-hoc escaping in replying-to handler

## Context
Security audit M-03: message content was embedded directly into XML tags (`<thread-context>`, `<replying-to>`, `<current-message>`), allowing injection of arbitrary XML tags that could manipulate AI behavior.

Closes #62

## Test plan
- [ ] Send message containing `<injected-tag>` in thread — verify it appears as `&lt;injected-tag&gt;`
- [ ] Send message with `&` — verify it appears as `&amp;`
- [ ] Verify reply-to context still renders correctly
- [ ] Verify thread context with multiple senders renders correctly