### PR TITLE
chore: bump SDK to ^1.3.1 (mention_all fix), release v1.4.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [1.4.6] - 2026-03-09
+
+### Changed
+- Bump `@coco-xyz/hxa-connect-sdk` from `^1.3.0` to `^1.3.1` (fix: @all / @所有人 now triggers delivery for all bots via mention_all field)
+
 ## [1.4.5] - 2026-03-07
 
 ### Added

--- a/SKILL.md
+++ b/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: hxa-connect
-version: 1.4.5
+version: 1.4.6
 description: HXA-Connect bot-to-bot communication channel via WebSocket. Use when replying to HXA-Connect messages or sending messages to other bots.
 type: communication
 user-invocable: false

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,23 +1,23 @@
 {
   "name": "zylos-hxa-connect",
-  "version": "1.4.5",
+  "version": "1.4.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "zylos-hxa-connect",
-      "version": "1.4.5",
+      "version": "1.4.6",
       "dependencies": {
-        "@coco-xyz/hxa-connect-sdk": "^1.3.0",
+        "@coco-xyz/hxa-connect-sdk": "^1.3.1",
         "https-proxy-agent": "^7.0.5",
         "undici": "^7.22.0",
         "ws": "^8.18.0"
       }
     },
     "node_modules/@coco-xyz/hxa-connect-sdk": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/@coco-xyz/hxa-connect-sdk/-/hxa-connect-sdk-1.3.0.tgz",
-      "integrity": "sha512-ploIdH/fhl91WZ/sz2N9SAvtPBbsZi3ueiLrbkG/dGuXRzy9vvC09JV6M7FMYdSsQZTxAXwsuzv95Pg5CbvujA==",
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/@coco-xyz/hxa-connect-sdk/-/hxa-connect-sdk-1.3.1.tgz",
+      "integrity": "sha512-y6Cue0GOYgXzCTPAH9pkL2KVq8GIlUibc8Ax4meBhg4sRTNciP/9V45q48D7H84OV3GOcgAB6U7dnoNQ1EaW/Q==",
       "license": "MIT",
       "dependencies": {
         "ws": "^8.18.0"

--- a/package.json
+++ b/package.json
@@ -1,10 +1,10 @@
 {
   "name": "zylos-hxa-connect",
-  "version": "1.4.5",
+  "version": "1.4.6",
   "type": "module",
   "private": true,
   "dependencies": {
-    "@coco-xyz/hxa-connect-sdk": "^1.3.0",
+    "@coco-xyz/hxa-connect-sdk": "^1.3.1",
     "https-proxy-agent": "^7.0.5",
     "undici": "^7.22.0",
     "ws": "^8.18.0"


### PR DESCRIPTION
## Summary
- Bump `@coco-xyz/hxa-connect-sdk` from `^1.3.0` to `^1.3.1`
- SDK v1.3.1 fix: `ThreadContext.isMention()` now checks `mention_all` field, enabling `@all` / `@所有人` to trigger delivery for all bots
- Version bump to v1.4.6

## Test plan
- [ ] Upgrade component: `zylos upgrade hxa-connect`
- [ ] Send `@all` message in test org thread
- [ ] Verify bot receives the message

🤖 Generated with [Claude Code](https://claude.com/claude-code)