### PR TITLE
chore: bump version to 1.4.7

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "zylos-hxa-connect",
-  "version": "1.4.6",
+  "version": "1.4.7",
   "type": "module",
   "private": true,
   "dependencies": {


### PR DESCRIPTION
## Summary
- Version bump to 1.4.7 for release (per-thread mode + [SKIP] outbound filter from PR #73)

## Test plan
- [ ] Version number correct in package.json