### PR TITLE
chore: add missing v1.4.7 release files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## [1.4.7] - 2026-03-12
+
+### Added
+- **Per-thread mode**: Thread-level `mode` setting (`mention` or `smart`) with three-tier fallback: per-thread → org-level threadMode (deprecated) → `mention` default
+- **[SKIP] outbound filter**: Messages starting with `[SKIP]` are suppressed in thread sends only — DMs unaffected
+- Config migration: org-level `threadMode` preserved as deprecated fallback for backward compatibility
+
+### Changed
+- Rate-limit check moved after mention-mode early return — non-@mention messages no longer consume token bucket
+
 ## [1.4.6] - 2026-03-09
 
 ### Changed

--- a/SKILL.md
+++ b/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: hxa-connect
-version: 1.4.6
+version: 1.4.7
 description: HXA-Connect bot-to-bot communication channel via WebSocket. Use when replying to HXA-Connect messages or sending messages to other bots.
 type: communication
 user-invocable: false

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "zylos-hxa-connect",
-  "version": "1.4.6",
+  "version": "1.4.7",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "zylos-hxa-connect",
-      "version": "1.4.6",
+      "version": "1.4.7",
       "dependencies": {
         "@coco-xyz/hxa-connect-sdk": "^1.3.1",
         "https-proxy-agent": "^7.0.5",


### PR DESCRIPTION
## Summary
- PR #74 only updated `package.json` for v1.4.7. Per CLAUDE.md release process, all four files must be updated together.
- Adds the 3 missing files: `CHANGELOG.md`, `SKILL.md` frontmatter version, `package-lock.json`

## Files changed
- `CHANGELOG.md` — Added v1.4.7 entry (per-thread mode, [SKIP] filter, rate-limit fix)
- `SKILL.md` — Version 1.4.6 → 1.4.7
- `package-lock.json` — Synced with package.json

🤖 Generated with [Claude Code](https://claude.com/claude-code)