### PR TITLE
fix: forward non-text message parts (image, file, link) to C4

### DIFF
--- a/src/bot.js
+++ b/src/bot.js
@@ -60,7 +60,14 @@ function formatAttachments(parts) {
   const refs = [];
   let truncated = 0;
   for (const part of parts) {
-    if (refs.length >= MAX_ATTACHMENT_PARTS) { truncated++; continue; }
+    if (refs.length >= MAX_ATTACHMENT_PARTS) {
+      // Only count parts that would have produced a ref
+      if (part.type === 'image' || part.type === 'file' || part.type === 'link'
+          || (part.type && part.url)) {
+        truncated++;
+      }
+      continue;
+    }
     switch (part.type) {
       case 'image':
         refs.push(part.alt

--- a/test/format-attachments.test.js
+++ b/test/format-attachments.test.js
@@ -25,7 +25,13 @@ function formatAttachments(parts) {
   const refs = [];
   let truncated = 0;
   for (const part of parts) {
-    if (refs.length >= MAX_ATTACHMENT_PARTS) { truncated++; continue; }
+    if (refs.length >= MAX_ATTACHMENT_PARTS) {
+      if (part.type === 'image' || part.type === 'file' || part.type === 'link'
+          || (part.type && part.url)) {
+        truncated++;
+      }
+      continue;
+    }
     switch (part.type) {
       case 'image':
         refs.push(part.alt
@@ -274,6 +280,24 @@ describe('formatAttachments', () => {
     ];
     const result = formatAttachments(parts);
     assert.ok(result.includes('[... and 1 more]'));
+  });
+
+  it('truncation count excludes text/json parts after limit', () => {
+    // After hitting the 20-ref limit, text/json parts shouldn't inflate the count
+    const parts = [
+      ...Array.from({ length: 20 }, (_, i) => ({
+        type: 'image', url: `https://cdn.example.com/${i}.png`
+      })),
+      { type: 'text', content: 'should not count' },
+      { type: 'json', content: { key: 'value' } },
+      { type: 'markdown', content: '# also not counted' },
+      { type: 'image', url: 'https://cdn.example.com/real-overflow.png' },
+      { type: 'file', url: 'https://cdn.example.com/extra.pdf', name: 'extra.pdf', mime_type: 'application/pdf' },
+    ];
+    const result = formatAttachments(parts);
+    // Only image + file after limit should be counted (2), not text/json/markdown (3)
+    assert.ok(result.includes('[... and 2 more]'));
+    assert.ok(!result.includes('[... and 5 more]'));
   });
 });
 


### PR DESCRIPTION
## Summary

Fixes #77 — Image, file, and link message parts were silently stripped by `extractText()`, which only collected parts with a string `content` field. Claude never received attachment metadata from thread or DM messages.

### Changes
- **`formatAttachments(parts)`** — Renders non-text parts as inline references:
  - `[image: alt — url]`, `[file: name (mime, size) — url]`, `[link: title — url]`
  - Capped at 20 parts to prevent DoS amplification
  - Default case for forward-compat with future SDK part types (e.g., audio/video)
- **`extractText(msg)`** — Now includes alt text, filenames, and link titles so @mentions in those fields still trigger thread delivery
- **DM handler** — Includes formatted attachments in C4 message
- **Thread onMention** — Includes attachments in `<current-message>` and `<thread-context>`
- **`formatBytes(bytes)`** — Human-readable file sizes with input validation
- **45 tests** — Unit + integration covering all part types, XML escaping, truncation, backward compat, edge cases

### Example output

**DM with image:**
```
[HXA:coco DM] alice said: Check this
[image: screenshot — https://cdn.example.com/photo.jpg]
```

**Thread with file:**
```xml
<current-message>
@bot review this
[file: spec.pdf (application/pdf, 10.0KB) — https://cdn.example.com/spec.pdf]
</current-message>
```

### Security review
- XML escaping applied consistently in thread context (escapeXml on attachments)
- DM path uses plain text (no XML parsing), consistent with existing content handling
- Parts capped at 20 to prevent amplification from messages with many parts
- `formatBytes` validates input (NaN, negative, non-numeric → `?B`)

### Backward compatibility
- Messages without `parts` field produce empty attachments string → zero behavior change
- Text/markdown/json parts are skipped by `formatAttachments` (already in `msg.content`)

## Test plan

- [x] 45 tests pass (`node --test test/format-attachments.test.js`)
- [ ] Manual: Send image in DM → verify Claude receives `[image: url]`
- [ ] Manual: Send image in thread with @mention → verify `<current-message>` includes attachment
- [ ] Manual: Send thread message with image but no @mention → verify mention detection from alt text

Ref: coco-xyz/hxa-connect#203

🤖 Generated with [Claude Code](https://claude.com/claude-code)