### PR TITLE
fix: upgrade undici to 7.24.6

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "dependencies": {
         "@coco-xyz/hxa-connect-sdk": "^1.6.0",
         "https-proxy-agent": "^7.0.5",
-        "undici": "^7.22.0",
+        "undici": "^7.24.6",
         "ws": "^8.18.0"
       }
     },
@@ -69,9 +69,9 @@
       "license": "MIT"
     },
     "node_modules/undici": {
-      "version": "7.22.0",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-7.22.0.tgz",
-      "integrity": "sha512-RqslV2Us5BrllB+JeiZnK4peryVTndy9Dnqq62S3yYRRTj0tFQCwEniUy2167skdGOy3vqRzEvl1Dm4sV2ReDg==",
+      "version": "7.24.6",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.24.6.tgz",
+      "integrity": "sha512-Xi4agocCbRzt0yYMZGMA6ApD7gvtUFaxm4ZmeacWI4cZxaF6C+8I8QfofC20NAePiB/IcvZmzkJ7XPa471AEtA==",
       "license": "MIT",
       "engines": {
         "node": ">=20.18.1"

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "dependencies": {
     "@coco-xyz/hxa-connect-sdk": "^1.6.0",
     "https-proxy-agent": "^7.0.5",
-    "undici": "^7.22.0",
+    "undici": "^7.24.6",
     "ws": "^8.18.0"
   }
 }


### PR DESCRIPTION
## Summary
- upgrade direct dependency `undici` from `^7.22.0` to `^7.24.6`
- refresh `package-lock.json` to pull the patched release
- resolve the 6 Dependabot alerts affecting `undici` >=7.0.0 <7.24.0

## Validation
- `npm audit`
- `node --test`