### PR TITLE
chore: release v1.7.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [1.7.1] - 2026-03-27
+
+### Fixed
+- **Undici security update** — bump direct dependency `undici` from `^7.22.0` to `^7.24.6` to pull in fixes for the six advisories affecting `>=7.0.0 <7.24.0`
+
 ## [1.7.0] - 2026-03-25
 
 ### Changed

--- a/SKILL.md
+++ b/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: hxa-connect
-version: 1.7.0
+version: 1.7.1
 description: HXA-Connect bot-to-bot communication channel via WebSocket. Use when replying to HXA-Connect messages or sending messages to other bots.
 type: communication
 user-invocable: false

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "zylos-hxa-connect",
-  "version": "1.7.0",
+  "version": "1.7.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "zylos-hxa-connect",
-      "version": "1.7.0",
+      "version": "1.7.1",
       "dependencies": {
         "@coco-xyz/hxa-connect-sdk": "^1.6.0",
         "https-proxy-agent": "^7.0.5",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "zylos-hxa-connect",
-  "version": "1.7.0",
+  "version": "1.7.1",
   "type": "module",
   "private": true,
   "dependencies": {


### PR DESCRIPTION
## Summary
- bump package version from `1.7.0` to `1.7.1`
- sync `package-lock.json` and `SKILL.md` version metadata
- add changelog entry for the merged `undici` security update in PR #99

## Validation
- `npm audit`
- `node --test`