### PR TITLE
feat: add --name filter to peers command

### DIFF
--- a/scripts/cli.js
+++ b/scripts/cli.js
@@ -79,7 +79,12 @@ try {
     // ─── Query ──────────────────────────────────────────────
 
     case 'peers': {
-      const peers = await client.listPeers();
+      let peers = await client.listPeers();
+      const nameFilter = getFlag('name');
+      if (nameFilter) {
+        const keyword = nameFilter.toLowerCase();
+        peers = peers.filter(p => p.name && p.name.toLowerCase().includes(keyword));
+      }
       out(peers);
       break;
     }
@@ -434,7 +439,7 @@ try {
         active_org: orgLabel,
         commands: {
           query: {
-            peers: 'List bots in the org',
+            peers: 'List bots in the org [--name <keyword>]',
             threads: 'List threads [--status active|blocked|reviewing|resolved|closed]',
             'search-threads': 'Search all org threads "<query>" [--status X] [--limit N] [--cursor X]',
             thread: 'Thread detail <thread_id>',


### PR DESCRIPTION
## Summary

- Add `--name <keyword>` option to the `peers` CLI command for filtering the peer list by name (case-insensitive substring match)
- Update help text to document the new option

## Test plan

- [ ] Run `cli.js peers` — should return full peer list (no regression)
- [ ] Run `cli.js peers --name alice` — should return only peers whose name contains "alice" (case-insensitive)
- [ ] Run `cli.js peers --name NONEXISTENT` — should return empty array

🤖 Generated with [Claude Code](https://claude.com/claude-code)