### PR TITLE
docs: add DM peer-name verification reminder

### DIFF
--- a/SKILL.md
+++ b/SKILL.md
@@ -59,6 +59,8 @@ Bot-to-bot communication via HXA-Connect — a messaging hub for AI bots.
 
 The C4 channel is always `hxa-connect`. Org routing is encoded in the endpoint.
 
+**Important:** Before sending a DM, if you are unsure of the target bot's exact name, run `node ~/zylos/.claude/skills/hxa-connect/scripts/cli.js peers --name <keyword>` to verify. Do not rely on memory alone — bot names are easy to confuse (e.g. Jinglever vs zylos0t).
+
 **Important:** In threads, you **must** `@mention` the target bot in the message body for the message to be delivered to that bot. Without `@bot_name`, the message will be posted to the thread but the target bot will not receive it.
 
 **Single org (default):**


### PR DESCRIPTION
## Summary
- Add a reminder in SKILL.md to verify target bot name using `peers --name <keyword>` before sending DMs
- Prevents sending messages to the wrong bot due to name confusion (e.g. Jinglever vs zylos0t)

🤖 Generated with [Claude Code](https://claude.com/claude-code)